### PR TITLE
Allow to add callbacks directly to items, handle item ids internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,35 +44,11 @@ fn main() {
 		'${@VMODROOT}/assets/icon.ico'
 	}
 	mut tray := vtray.create(icon, tooltip: 'VTray Demo!')
-	tray.add_item(vtray.MenuItem{
-		text: 'Edit'
-		checkable: true
-	})
-	tray.add_item(vtray.MenuItem{
-		text: 'Copy'
-		disabled: true
-	})
-	tray.add_item(vtray.MenuItem{
-		text: 'Quit'
-		on_click: fn [tray] () {
-			tray.destroy()
-		}
-	})
-	tray.init()
+	tray.add_item('Edit', checkable: true)
+	tray.add_item('Copy', disabled: true)
+	tray.add_item('Quit', on_click: tray.destroy)
 	tray.run()
 	tray.destroy()
-}
-```
-
-Edit v.mod
-
-```v
-Module {
-	name: 'myapp'
-	description: ''
-	version: '0.0.1'
-	license: 'MIT'
-	dependencies: ['ouri028.vtray']
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,30 +43,24 @@ fn main() {
 	} $else {
 		'${@VMODROOT}/assets/icon.ico'
 	}
-	mut systray := &vtray.VTrayApp{
-		identifier: 'VTray!'
-		tooltip: 'VTray Demo!'
-		icon: icon
-	}
-	systray.items = [
-		&vtray.VTrayMenuItem{
-			text: 'Edit'
-			checkable: true
-		},
-		&vtray.VTrayMenuItem{
-			text: 'Copy'
-			disabled: true
-		},
-		&vtray.VTrayMenuItem{
-			text: 'Quit'
-			on_click: fn [systray] () {
-				systray.destroy()
-			}
-		},
-	]
-	systray.vtray_init()
-	systray.run()
-	systray.destroy()
+	mut tray := vtray.create(icon, tooltip: 'VTray Demo!')
+	tray.add_item(vtray.MenuItem{
+		text: 'Edit'
+		checkable: true
+	})
+	tray.add_item(vtray.MenuItem{
+		text: 'Copy'
+		disabled: true
+	})
+	tray.add_item(vtray.MenuItem{
+		text: 'Quit'
+		on_click: fn [tray] () {
+			tray.destroy()
+		}
+	})
+	tray.init()
+	tray.run()
+	tray.destroy()
 }
 ```
 
@@ -105,25 +99,25 @@ Module {
 ```v
 module vtray
 
-struct VTrayMenuItem {
+struct MenuItem {
 pub mut:
 	text      string
 	checked   bool
 	checkable bool
 	disabled  bool
 }
-struct VTrayApp {
+struct Tray {
 mut:
 	tray &VTray = unsafe { nil }
 pub mut:
 	identifier string
 	tooltip    string
 	icon       string
-	items      []&VTrayMenuItem
+	items      []&MenuItem
 }
-fn (mut v VTrayApp) vtray_init()
-fn (v &VTrayApp) run()
-fn (v &VTrayApp) destroy()
+fn (mut v Tray) vtray_init()
+fn (v &Tray) run()
+fn (v &Tray) destroy()
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ module main
 
 import ouri028.vtray
 
-enum MenuItems {
-	edit = 1
-	copy = 2
-	quit = 3
-}
-
 fn main() {
 	icon := $if macos {
 		'${@VMODROOT}/assets/icon.png'
@@ -53,30 +47,23 @@ fn main() {
 		identifier: 'VTray!'
 		tooltip: 'VTray Demo!'
 		icon: icon
-		items: [
-			&vtray.VTrayMenuItem{
-				id: int(MenuItems.edit)
-				text: 'Edit'
-				checkable: true
-			},
-			&vtray.VTrayMenuItem{
-				id: int(MenuItems.copy)
-				text: 'Copy'
-				disabled: true
-			},
-			&vtray.VTrayMenuItem{
-				id: int(MenuItems.quit)
-				text: 'Quit'
-			},
-		]
 	}
-	on_click := fn [systray] (mut menu_item vtray.VTrayMenuItem) {
-		println(menu_item)
-		if menu_item.id == int(MenuItems.quit) {
-			systray.destroy()
-		}
-	}
-	systray.on_click = on_click
+	systray.items = [
+		&vtray.VTrayMenuItem{
+			text: 'Edit'
+			checkable: true
+		},
+		&vtray.VTrayMenuItem{
+			text: 'Copy'
+			disabled: true
+		},
+		&vtray.VTrayMenuItem{
+			text: 'Quit'
+			on_click: fn [systray] () {
+				systray.destroy()
+			}
+		},
+	]
 	systray.vtray_init()
 	systray.run()
 	systray.destroy()
@@ -113,28 +100,26 @@ Module {
 
 ![image5.png](assets%2Fimage5.png)
 
-### Struct Definitions
+### Definitions
 
 ```v
 module vtray
 
 struct VTrayMenuItem {
 pub mut:
-        id        int
-        text      string
-        checked   bool
-        checkable bool
-        disabled  bool
+	text      string
+	checked   bool
+	checkable bool
+	disabled  bool
 }
 struct VTrayApp {
 mut:
-        tray &VTray = unsafe { nil }
+	tray &VTray = unsafe { nil }
 pub mut:
-        identifier string
-        tooltip    string
-        icon       string
-        items      []&VTrayMenuItem
-        on_click   fn (menu_item &VTrayMenuItem) = unsafe { nil }
+	identifier string
+	tooltip    string
+	icon       string
+	items      []&VTrayMenuItem
 }
 fn (mut v VTrayApp) vtray_init()
 fn (v &VTrayApp) run()

--- a/c/linux/tray.c
+++ b/c/linux/tray.c
@@ -5,7 +5,7 @@ void *GLOBAL_TRAY = NULL;
 
 static void on_menu_item_clicked(GtkMenuItem *menu_item, gpointer user_data)
 {
-    struct VTrayMenuItem *item = (struct VTrayMenuItem *)user_data;
+    struct MenuItem *item = (struct MenuItem *)user_data;
     struct VTray *tray = (struct VTray *)get_global_vtray();
     if (tray != NULL)
     {
@@ -19,7 +19,7 @@ static void on_menu_item_clicked(GtkMenuItem *menu_item, gpointer user_data)
 
 static void on_toggle_menu_item_clicked(GtkCheckMenuItem *menu_item, gpointer user_data)
 {
-    struct VTrayMenuItem *item = (struct VTrayMenuItem *)user_data;
+    struct MenuItem *item = (struct MenuItem *)user_data;
     struct VTray *tray = (struct VTray *)get_global_vtray();
     if (tray != NULL)
     {
@@ -31,7 +31,7 @@ static void on_toggle_menu_item_clicked(GtkCheckMenuItem *menu_item, gpointer us
     }
 }
 
-struct VTray *vtray_init(VTrayParams *params, size_t num_items, struct VTrayMenuItem *items[])
+struct VTray *vtray_init(VTrayParams *params, size_t num_items, struct MenuItem *items[])
 {
     struct VTray *tray = (struct VTray *)malloc(sizeof(struct VTray));
     if (!tray)
@@ -79,7 +79,7 @@ void vtray_construct(struct VTray *parent)
 
         for (size_t i = 0; i < parent->num_items; i++)
         {
-            struct VTrayMenuItem *item = parent->items[i];
+            struct MenuItem *item = parent->items[i];
             GtkMenuItem *menu_item;
 
             if (item->checkable)
@@ -114,7 +114,7 @@ void vtray_construct(struct VTray *parent)
 
 void vtray_update_menu_item(struct VTray *tray, int menu_id)
 {
-    VTrayMenuItem *item = get_vmenu_item_by_id(menu_id, tray);
+    MenuItem *item = get_vmenu_item_by_id(menu_id, tray);
     GtkMenuItem *menu_item = get_menu_item_by_label(tray, string_to_char(item->text));
     if (item == NULL)
     {
@@ -154,7 +154,7 @@ GtkMenuItem *get_menu_item_by_label(struct VTray *tray, char *label)
     return NULL;
 }
 
-VTrayMenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray)
+MenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray)
 {
     for (size_t i = 0; i < tray->num_items; i++)
     {
@@ -163,7 +163,7 @@ VTrayMenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray)
             return tray->items[i];
         }
     }
-    return (VTrayMenuItem *){0};
+    return (MenuItem *){0};
 }
 
 void vtray_exit(struct VTray *tray)

--- a/c/linux/tray.h
+++ b/c/linux/tray.h
@@ -8,15 +8,15 @@
 #include "utils.h"
 
 typedef struct VTrayParams VTrayParams;
-typedef struct VTrayMenuItem VTrayMenuItem;
-typedef void (*CallbackFunction)(VTrayMenuItem *menu_item);
+typedef struct MenuItem MenuItem;
+typedef void (*CallbackFunction)(MenuItem *menu_item);
 
 struct VTray
 {
     AppIndicator *indicator;
     GtkWidget *menu;
     CallbackFunction on_click;
-    struct VTrayMenuItem **items;
+    struct MenuItem **items;
     size_t num_items;
     size_t num_menus;
     GtkMenuItem **menus;
@@ -30,7 +30,7 @@ struct VTrayParams
     CallbackFunction on_click;
 };
 
-struct VTrayMenuItem
+struct MenuItem
 {
     int id;
     String text;
@@ -39,7 +39,7 @@ struct VTrayMenuItem
     bool disabled;
 };
 
-struct VTray *vtray_init(VTrayParams *params, size_t num_items, struct VTrayMenuItem *items[]);
+struct VTray *vtray_init(VTrayParams *params, size_t num_items, struct MenuItem *items[]);
 
 void vtray_run(struct VTray *tray);
 
@@ -53,7 +53,7 @@ void vtray_update_menu_item(struct VTray *tray, int menu_id);
 
 GtkMenuItem *get_menu_item_by_label(struct VTray *tray, char *label);
 
-VTrayMenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray);
+MenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray);
 
 void set_global_vtray(void *ptr);
 

--- a/c/macos/tray.m
+++ b/c/macos/tray.m
@@ -47,13 +47,13 @@ static NSString *string_to_nsstring(string str)
   NSStatusItem *statusItem;    // our button
   int num_items;
   vtray__VTrayParams *trayParams; // VTrayParams is defined in tray.v
-  vtray__VTrayMenuItem **menuItems;
+  vtray__MenuItem **menuItems;
 }
 @end
 
 @implementation AppDelegate
 - (AppDelegate *)initWithParams:(vtray__VTrayParams *)params
-                        itemsArray:(vtray__VTrayMenuItem *[])itemsArray
+                        itemsArray:(vtray__MenuItem *[])itemsArray
                     numItems:(int)numItems {
   if (self = [super init]) {
     trayParams = params;
@@ -69,8 +69,8 @@ static NSString *string_to_nsstring(string str)
 // Called when NSMenuItem is clicked.
 - (void)onAction:(id)sender {
   NSMenuItem *menuItem = (NSMenuItem *)sender;
-  struct vtray__VTrayMenuItem *item =
-      (struct vtray__VTrayMenuItem *)[[sender representedObject] pointerValue];
+  struct vtray__MenuItem *item =
+      (struct vtray__MenuItem *)[[sender representedObject] pointerValue];
 
   if (item && item->checkable) {
     item->checked = !item->checked; // Toggle the checked state
@@ -144,7 +144,7 @@ static NSString *string_to_nsstring(string str)
 @end
 
 // Initializes NSApplication and NSStatusItem, aka system tray menu item.
-vtray__VTray *vtray_init(vtray__VTrayParams *params, int numItems, vtray__VTrayMenuItem *itemsArray[]) {
+vtray__VTray *vtray_init(vtray__VTrayParams *params, int numItems, vtray__MenuItem *itemsArray[]) {
   NSApplication *app = [NSApplication sharedApplication];
   AppDelegate *appDelegate = [[AppDelegate alloc] initWithParams:params itemsArray:itemsArray numItems:numItems];
 

--- a/c/windows/tray.c
+++ b/c/windows/tray.c
@@ -45,7 +45,7 @@ LRESULT CALLBACK vtray_wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
     return 0;
 }
 
-struct VTray *vtray_init(VTrayParams *params, size_t num_items, struct VTrayMenuItem *items[])
+struct VTray *vtray_init(VTrayParams *params, size_t num_items, struct MenuItem *items[])
 {
     struct VTray *tray = (struct VTray *)malloc(sizeof(struct VTray));
     if (!tray)
@@ -145,7 +145,7 @@ void vtray_construct(struct VTray *parent)
     {
         for (size_t i = 0; i < parent->num_items; i++)
         {
-            struct VTrayMenuItem *item = parent->items[i];
+            struct MenuItem *item = parent->items[i];
             MENUITEMINFO menuItem;
             memset(&menuItem, 0, sizeof(MENUITEMINFO));
             menuItem.cbSize = sizeof(MENUITEMINFO);
@@ -201,7 +201,7 @@ void vtray_update_menu_item(struct VTray *tray, int menu_id, bool checked)
         return;
     }
     menuItemInfo.fMask = MIIM_STATE;
-    VTrayMenuItem *item = get_vmenu_item_by_id(menu_id, tray);
+    MenuItem *item = get_vmenu_item_by_id(menu_id, tray);
     if (item == NULL)
     {
         fprintf(stderr, "Failed to find menu item with ID %d\n", menu_id);
@@ -240,7 +240,7 @@ MENUITEMINFO get_menu_item_by_id(HMENU menu, UINT menu_id)
     return menuItemInfo;
 }
 
-VTrayMenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray)
+MenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray)
 {
     for (size_t i = 0; i < tray->num_items; i++)
     {
@@ -249,7 +249,7 @@ VTrayMenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray)
             return tray->items[i];
         }
     }
-    return (VTrayMenuItem *){0};
+    return (MenuItem *){0};
 }
 
 void vtray_run(struct VTray *tray)

--- a/c/windows/tray.h
+++ b/c/windows/tray.h
@@ -12,9 +12,9 @@
 #define ID_TRAYICON 100
 
 typedef struct VTrayParams VTrayParams;
-typedef struct VTrayMenuItem VTrayMenuItem;
+typedef struct MenuItem MenuItem;
 
-typedef void (*CallbackFunction)(VTrayMenuItem *menu_item);
+typedef void (*CallbackFunction)(MenuItem *menu_item);
 
 struct VTrayParams
 {
@@ -24,7 +24,7 @@ struct VTrayParams
     CallbackFunction on_click;
 };
 
-struct VTrayMenuItem
+struct MenuItem
 {
     int id;
     String text;
@@ -43,11 +43,11 @@ struct VTray
     HWND hwnd;
     wchar_t *tooltip;
     CallbackFunction on_click;
-    struct VTrayMenuItem **items;
+    struct MenuItem **items;
     size_t num_items;
 };
 
-struct VTray *vtray_init(VTrayParams *params, size_t num_items, struct VTrayMenuItem *items[]);
+struct VTray *vtray_init(VTrayParams *params, size_t num_items, struct MenuItem *items[]);
 
 void vtray_exit(struct VTray *tray);
 
@@ -63,7 +63,7 @@ BOOL is_menu_item_checked(HMENU menu, UINT menuId);
 
 MENUITEMINFO get_menu_item_by_id(HMENU menu, UINT menu_id);
 
-VTrayMenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray);
+MenuItem *get_vmenu_item_by_id(int menu_id, struct VTray *tray);
 
 void vtray_run(struct VTray *tray);
 

--- a/example/basic_usage.v
+++ b/example/basic_usage.v
@@ -23,7 +23,6 @@ fn main() {
 			tray.destroy()
 		}
 	})
-	tray.init()
 	tray.run()
 	tray.destroy()
 }

--- a/example/basic_usage.v
+++ b/example/basic_usage.v
@@ -8,28 +8,22 @@ fn main() {
 	} $else {
 		'${@VMODROOT}/assets/icon.ico'
 	}
-	mut systray := &vtray.VTrayApp{
-		identifier: 'VTray!'
-		tooltip: 'VTray Demo!'
-		icon: icon
-	}
-	systray.items = [
-		&vtray.VTrayMenuItem{
-			text: 'Edit'
-			checkable: true
-		},
-		&vtray.VTrayMenuItem{
-			text: 'Copy'
-			disabled: true
-		},
-		&vtray.VTrayMenuItem{
-			text: 'Quit'
-			on_click: fn [systray] () {
-				systray.destroy()
-			}
-		},
-	]
-	systray.vtray_init()
-	systray.run()
-	systray.destroy()
+	mut tray := vtray.create(icon, tooltip: 'VTray Demo!')
+	tray.add_item(vtray.MenuItem{
+		text: 'Edit'
+		checkable: true
+	})
+	tray.add_item(vtray.MenuItem{
+		text: 'Copy'
+		disabled: true
+	})
+	tray.add_item(vtray.MenuItem{
+		text: 'Quit'
+		on_click: fn [tray] () {
+			tray.destroy()
+		}
+	})
+	tray.init()
+	tray.run()
+	tray.destroy()
 }

--- a/example/basic_usage.v
+++ b/example/basic_usage.v
@@ -9,20 +9,9 @@ fn main() {
 		'${@VMODROOT}/assets/icon.ico'
 	}
 	mut tray := vtray.create(icon, tooltip: 'VTray Demo!')
-	tray.add_item(vtray.MenuItem{
-		text: 'Edit'
-		checkable: true
-	})
-	tray.add_item(vtray.MenuItem{
-		text: 'Copy'
-		disabled: true
-	})
-	tray.add_item(vtray.MenuItem{
-		text: 'Quit'
-		on_click: fn [tray] () {
-			tray.destroy()
-		}
-	})
+	tray.add_item('Edit', checkable: true)
+	tray.add_item('Copy', disabled: true)
+	tray.add_item('Quit', on_click: tray.destroy)
 	tray.run()
 	tray.destroy()
 }

--- a/example/basic_usage.v
+++ b/example/basic_usage.v
@@ -2,12 +2,6 @@ module main
 
 import ouri028.vtray
 
-enum MenuItems {
-	edit = 1
-	copy = 2
-	quit = 3
-}
-
 fn main() {
 	icon := $if macos {
 		'${@VMODROOT}/assets/icon.png'
@@ -18,30 +12,23 @@ fn main() {
 		identifier: 'VTray!'
 		tooltip: 'VTray Demo!'
 		icon: icon
-		items: [
-			&vtray.VTrayMenuItem{
-				id: int(MenuItems.edit)
-				text: 'Edit'
-				checkable: true
-			},
-			&vtray.VTrayMenuItem{
-				id: int(MenuItems.copy)
-				text: 'Copy'
-				disabled: true
-			},
-			&vtray.VTrayMenuItem{
-				id: int(MenuItems.quit)
-				text: 'Quit'
-			},
-		]
 	}
-	on_click := fn [systray] (mut menu_item vtray.VTrayMenuItem) {
-		println(menu_item)
-		if menu_item.id == int(MenuItems.quit) {
-			systray.destroy()
-		}
-	}
-	systray.on_click = on_click
+	systray.items = [
+		&vtray.VTrayMenuItem{
+			text: 'Edit'
+			checkable: true
+		},
+		&vtray.VTrayMenuItem{
+			text: 'Copy'
+			disabled: true
+		},
+		&vtray.VTrayMenuItem{
+			text: 'Quit'
+			on_click: fn [systray] () {
+				systray.destroy()
+			}
+		},
+	]
 	systray.vtray_init()
 	systray.run()
 	systray.destroy()

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -35,9 +35,9 @@ struct VTrayParams {
 	identifier string
 	tooltip    string
 	icon       string
-	on_click   fn (menu_item &VTrayMenuItem) = unsafe { nil }
+	on_click   fn (menu_item &MenuItem) = unsafe { nil }
 }
 
-fn C.vtray_init(params &VTrayParams, num_items usize, items []&VTrayMenuItem) &VTray
+fn C.vtray_init(params &VTrayParams, num_items usize, items []&MenuItem) &VTray
 fn C.vtray_run(tray &VTray)
 fn C.vtray_exit(tray &VTray)

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -38,6 +38,14 @@ struct VTrayParams {
 	on_click   fn (menu_item &MenuItem) = unsafe { nil }
 }
 
+struct MenuItem {
+	id        int
+	text      string
+	checked   bool
+	checkable bool
+	disabled  bool
+}
+
 fn C.vtray_init(params &VTrayParams, num_items usize, items []&MenuItem) &VTray
 fn C.vtray_run(tray &VTray)
 fn C.vtray_exit(tray &VTray)

--- a/src/lib.v
+++ b/src/lib.v
@@ -1,7 +1,7 @@
 module vtray
 
 // Tray is the main struct that represents the tray app.
-[noinit]
+[heap; noinit]
 pub struct Tray {
 mut:
 	instance   &VTray = unsafe { nil }
@@ -20,11 +20,8 @@ pub struct CreatOptions {
 }
 
 // MenuItem is a menu item that can be added to the tray.
-pub struct MenuItem {
-mut:
-	id int
-pub mut:
-	text      string
+[params]
+pub struct MenuItemOptions {
 	checked   bool
 	checkable bool
 	disabled  bool
@@ -42,13 +39,16 @@ pub fn create(icon_path string, opts CreatOptions) &Tray {
 }
 
 // add_item adds an item to the tray.
-pub fn (mut t Tray) add_item(item MenuItem) {
+pub fn (mut t Tray) add_item(text string, opts MenuItemOptions) {
 	id := t.last_id++
 	t.items << &MenuItem{
-		...item
 		id: id
+		text: text
+		checked: opts.checked
+		checkable: opts.checkable
+		disabled: opts.disabled
 	}
-	if cb := item.on_click {
+	if cb := opts.on_click {
 		t.callbacks[id] = cb
 	}
 }

--- a/src/lib.v
+++ b/src/lib.v
@@ -31,20 +31,6 @@ pub mut:
 	on_click  ?fn ()
 }
 
-// For MacOS the tray icon size must be 22x22 pixels in order for it to render correctly.
-pub fn (mut t Tray) init() {
-	t.instance = C.vtray_init(&VTrayParams{
-		identifier: t.identifier
-		tooltip: t.tooltip
-		icon: t.icon
-		on_click: fn [t] (menu_item &MenuItem) {
-			if cb := t.callbacks[menu_item.id] {
-				cb()
-			}
-		}
-	}, usize(t.items.len), t.items.data)
-}
-
 // create Create a Tray.
 pub fn create(icon_path string, opts CreatOptions) &Tray {
 	return &Tray{
@@ -66,7 +52,17 @@ pub fn (mut t Tray) add_item(item MenuItem) {
 }
 
 // run Run the tray app.
-pub fn (t &Tray) run() {
+pub fn (mut t Tray) run() {
+	t.instance = C.vtray_init(&VTrayParams{
+		identifier: t.identifier
+		tooltip: t.tooltip
+		icon: t.icon
+		on_click: fn [t] (menu_item &MenuItem) {
+			if cb := t.callbacks[menu_item.id] {
+				cb()
+			}
+		}
+	}, usize(t.items.len), t.items.data)
 	C.vtray_run(t.instance)
 }
 

--- a/src/lib.v
+++ b/src/lib.v
@@ -31,7 +31,8 @@ pub mut:
 	on_click  ?fn ()
 }
 
-// create Create a Tray.
+// create creates the tray.
+// On macOS, the tray icon size must be 22x22 pixels to be rendered correctly.
 pub fn create(icon_path string, opts CreatOptions) &Tray {
 	return &Tray{
 		icon: icon_path
@@ -40,6 +41,7 @@ pub fn create(icon_path string, opts CreatOptions) &Tray {
 	}
 }
 
+// add_item adds an item to the tray.
 pub fn (mut t Tray) add_item(item MenuItem) {
 	id := t.last_id++
 	t.items << &MenuItem{
@@ -51,7 +53,7 @@ pub fn (mut t Tray) add_item(item MenuItem) {
 	}
 }
 
-// run Run the tray app.
+// run runs the tray app.
 pub fn (mut t Tray) run() {
 	t.instance = C.vtray_init(&VTrayParams{
 		identifier: t.identifier
@@ -66,7 +68,7 @@ pub fn (mut t Tray) run() {
 	C.vtray_run(t.instance)
 }
 
-// destroy Destroy the tray app and free the memory.
+// destroy destroys the tray app and frees allocated memory.
 pub fn (t &Tray) destroy() {
 	C.vtray_exit(t.instance)
 }

--- a/src/lib.v
+++ b/src/lib.v
@@ -10,7 +10,7 @@ mut:
 	tooltip    string
 	items      []&MenuItem
 	callbacks  map[int]fn ()
-	last_id    int
+	last_id    int = 1
 }
 
 [params]


### PR DESCRIPTION
Awesome updates @Ouri028 made it a lot cleaner :blue_heart:!

The change I thought of that I mentioned here https://github.com/Ouri028/VTray/pull/2 is still applicable. 

The changes will allow to add `on_click` callbacks directly to items instead of needing to create an additional handler and match for items ids. It might make vtray even more simple and straightforward to use. It's a breaking change. Let me know your thoughts. 

- Example current:
  ```v
  module main
  
  import ouri028.vtray
  
  enum MenuItems {
  	edit = 1
  	copy = 2
  	quit = 3
  }
  
  fn main() {
  	icon := $if macos {
  		'${@VMODROOT}/assets/icon.png'
  	} $else {
  		'${@VMODROOT}/assets/icon.ico'
  	}
  	mut systray := &vtray.VTrayApp{
  		identifier: 'VTray!'
  		tooltip: 'VTray Demo!'
  		icon: icon
  		items: [
  			&vtray.VTrayMenuItem{
  				id: int(MenuItems.edit)
  				text: 'Edit'
  				checkable: true
  			},
  			&vtray.VTrayMenuItem{
  				id: int(MenuItems.copy)
  				text: 'Copy'
  				disabled: true
  			},
  			&vtray.VTrayMenuItem{
  				id: int(MenuItems.quit)
  				text: 'Quit'
  			},
  		]
  	}
  	on_click := fn [systray] (mut menu_item vtray.VTrayMenuItem) {
  		println(menu_item)
  		if menu_item.id == int(MenuItems.quit) {
  			systray.destroy()
  		}
  	}
  	systray.on_click = on_click
  	systray.vtray_init()
  	systray.run()
  	systray.destroy()
  }
  ```

- Example with the PRs changes:
  ```v
  module main
  
  import ouri028.vtray
  
  fn main() {
  	icon := $if macos {
  		'${@VMODROOT}/assets/icon.png'
  	} $else {
  		'${@VMODROOT}/assets/icon.ico'
  	}
  	mut systray := &vtray.VTrayApp{
  		identifier: 'VTray!'
  		tooltip: 'VTray Demo!'
  		icon: icon
  	}
  	systray.items = [
  		&vtray.VTrayMenuItem{
  			text: 'Edit'
  			checkable: true
  		},
  		&vtray.VTrayMenuItem{
  			text: 'Copy'
  			disabled: true
  		},
  		&vtray.VTrayMenuItem{
  			text: 'Quit'
  			on_click: fn [systray] () {
  				systray.destroy()
  			}
  		},
  	]
  	systray.vtray_init()
  	systray.run()
  	systray.destroy()
  }
  ```