### PR TITLE
Allow to set fn() or fn(item &MenuItem) for on_click cbs

### DIFF
--- a/example/basic_usage.v
+++ b/example/basic_usage.v
@@ -11,13 +11,11 @@ fn main() {
 	mut tray := vtray.create(icon, tooltip: 'VTray Demo!')
 	tray.add_item('Edit',
 		checkable: true
-		on_click: fn [tray] () {
-			if x := tray.get_item('Edit') {
-				if x.checked {
-					tray.set_icon('${@VMODROOT}/assets/test.ico')
-				} else {
-					tray.set_icon('${@VMODROOT}/assets/icon.ico')
-				}
+		on_click: fn [tray] (item &vtray.MenuItem) {
+			if item.checked {
+				tray.set_icon('${@VMODROOT}/assets/test.ico')
+			} else {
+				tray.set_icon('${@VMODROOT}/assets/icon.ico')
 			}
 		}
 	)

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -38,15 +38,6 @@ struct VTrayParams {
 	on_click   fn (menu_item &MenuItem) = unsafe { nil }
 }
 
-pub struct MenuItem {
-pub:
-	id        int
-	text      string
-	checked   bool
-	checkable bool
-	disabled  bool
-}
-
 fn C.vtray_init(params &VTrayParams, num_items usize, items []&MenuItem) &VTray
 fn C.vtray_run(tray &VTray)
 fn C.vtray_exit(tray &VTray)

--- a/src/lib.c.v
+++ b/src/lib.c.v
@@ -38,8 +38,7 @@ struct VTrayParams {
 	on_click   fn (menu_item &MenuItem) = unsafe { nil }
 }
 
-[heap]
-struct MenuItem {
+pub struct MenuItem {
 pub:
 	id        int
 	text      string

--- a/src/lib.v
+++ b/src/lib.v
@@ -13,6 +13,15 @@ mut:
 	last_id    int = 1
 }
 
+pub struct MenuItem {
+pub:
+	id        int
+	text      string
+	checked   bool
+	checkable bool
+	disabled  bool
+}
+
 [params]
 pub struct CreatOptions {
 	identifier string = 'VTray'

--- a/src/lib.v
+++ b/src/lib.v
@@ -9,7 +9,7 @@ mut:
 	identifier string
 	tooltip    string
 	items      []&MenuItem
-	callbacks  map[int]fn ()
+	callbacks  map[int]ItemCallback
 	last_id    int = 1
 }
 
@@ -25,8 +25,10 @@ pub struct MenuItemOptions {
 	checked   bool
 	checkable bool
 	disabled  bool
-	on_click  ?fn ()
+	on_click  ?ItemCallback
 }
+
+type ItemCallback = fn () | fn (menu_item &MenuItem)
 
 // create creates the tray.
 // On macOS, the tray icon size must be 22x22 pixels to be rendered correctly.
@@ -75,8 +77,14 @@ pub fn (mut t Tray) run() {
 		tooltip: t.tooltip
 		icon: t.icon
 		on_click: fn [t] (menu_item &MenuItem) {
-			if cb := t.callbacks[menu_item.id] {
-				cb()
+			cb := t.callbacks[menu_item.id] or { return }
+			match cb {
+				fn (menu_item &MenuItem) {
+					cb(menu_item)
+				}
+				fn () {
+					cb()
+				}
 			}
 		}
 	}, usize(t.items.len), t.items.data)


### PR DESCRIPTION
Items that use their own fields in a callback now don't need to call get_item() for themselves anymore but can use a `fn (item &vtray.MenuItem)` callback.

```v
fn [tray] () {
	if x := tray.get_item('Edit') {
		if x.checked {
			tray.set_icon('${@VMODROOT}/assets/test.ico')
		} else {
			tray.set_icon('${@VMODROOT}/assets/icon.ico')
		}
	}
}
```

can now be:
```v
fn [tray] (item &vtray.MenuItem) {
	if item.checked {
		 tray.set_icon('${@VMODROOT}/assets/test.ico')
	} else {
		tray.set_icon('${@VMODROOT}/assets/icon.ico')
	}
}
```
void `fn()` callbacks are still possible.